### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,5 +1,8 @@
 name: Operation Check
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/suzukimain/auto_diffusers/security/code-scanning/1](https://github.com/suzukimain/auto_diffusers/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will restrict the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow. Since the workflow does not perform any repository write operations, we will set `contents: read` as the only permission. This ensures the workflow has read-only access to the repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
